### PR TITLE
Move cache management out of queries

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,10 +1,19 @@
+'use server';
+
 import { ScenarioUploadDialog } from '~/components/scenario/scenario-upload-dialog';
 import { ScenariosTable } from '~/components/scenario/scenario-table';
 import { getScenarios } from '~/lib/db/queries';
 import { ThemeToggle } from '~/components/theme/theme-toggle';
+import { unstable_cache } from 'next/cache';
+import { cacheTags } from '~/lib/constants';
+
+const getScenariosCached = unstable_cache(getScenarios, [cacheTags.scenarios], {
+    revalidate: 3600,
+    tags: [cacheTags.scenarios]
+});
 
 export default async function App() {
-    const scenarios = await getScenarios();
+    const scenarios = await getScenariosCached();
 
     return (
         <main className="flex min-h-svh flex-col items-center justify-center gap-6 p-6 md:p-10">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,3 @@
-'use server';
-
 import { ScenarioUploadDialog } from '~/components/scenario/scenario-upload-dialog';
 import { ScenariosTable } from '~/components/scenario/scenario-table';
 import { getScenarios } from '~/lib/db/queries';

--- a/lib/db/queries.ts
+++ b/lib/db/queries.ts
@@ -2,20 +2,11 @@ import { eq } from 'drizzle-orm';
 import { db } from '.';
 import { ScenariosTable } from './schema';
 import { Scenario, scenarioSchema } from '~/lib/domain/scenario';
-import { unstable_cache } from 'next/cache';
-import { cacheTags } from '~/lib/constants';
 
-export const getScenarios = unstable_cache(
-    async () => {
-        const res = await db.query.ScenariosTable.findMany();
-        return res.map((row) => ({ ...row, data: scenarioSchema.parse(JSON.parse(row.data)) }));
-    },
-    [cacheTags.scenarios],
-    {
-        revalidate: 3600,
-        tags: [cacheTags.scenarios]
-    }
-);
+export const getScenarios = async () => {
+    const res = await db.query.ScenariosTable.findMany();
+    return res.map((row) => ({ ...row, data: scenarioSchema.parse(JSON.parse(row.data)) }));
+};
 
 export const getScenario = async (id: number) => {
     const res = await db.query.ScenariosTable.findFirst({ where: (scenario, { eq }) => eq(scenario.id, id) });


### PR DESCRIPTION
Because queries should refer only to database queries, not Vercel's cache