### PR TITLE
Properly handle scenario-id

### DIFF
--- a/app/play/[scenarioId]/page.tsx
+++ b/app/play/[scenarioId]/page.tsx
@@ -3,8 +3,8 @@ import { notFound } from 'next/navigation';
 import { getScenario } from '~/lib/db/queries';
 
 export default async function Page({ params }: { params: Promise<{ scenarioId: number }> }) {
-    // TODO: if id is not a number, redirect to 404
     const id = (await params).scenarioId;
+    if (isNaN(id)) notFound();
 
     const scenario = await getScenario(id);
 


### PR DESCRIPTION
Check scenario-id type before using it to getScenario, to avoid runtime error
