### PR TITLE
Limit map boundaries and interactions

### DIFF
--- a/components/scenario/scenario-table.tsx
+++ b/components/scenario/scenario-table.tsx
@@ -17,31 +17,6 @@ export const columns: ColumnDef<{ id: number; data: Scenario }>[] = [
         accessorKey: 'data'
     },
     {
-        accessorKey: 'lat',
-        header: () => <div className="text-right">Latitude</div>,
-        cell: ({ row }) => {
-            const scenario = row.getValue('data') as Scenario;
-            return <div className="text-right font-medium">{scenario.view.latitude.toFixed(4)}</div>;
-        }
-    },
-    {
-        accessorKey: 'lon',
-        header: () => <div className="text-right">Longitude</div>,
-        cell: ({ row }) => {
-            const scenario = row.getValue('data') as Scenario;
-            return <div className="text-right font-medium">{scenario.view.longitude.toFixed(4)}</div>;
-        }
-    },
-    {
-        accessorKey: 'zoom',
-        header: () => <div className="text-right">Zoom</div>,
-        cell: ({ row }) => {
-            const scenario = row.getValue('data') as Scenario;
-
-            return <div className="text-right font-medium">{scenario.view.zoom.toFixed(0)}</div>;
-        }
-    },
-    {
         accessorKey: 'flights',
         header: () => <div className="text-right">Flights</div>,
         cell: ({ row }) => {

--- a/lib/domain/scenario.ts
+++ b/lib/domain/scenario.ts
@@ -29,16 +29,12 @@ export type Flight = z.infer<typeof flightSchema>;
 
 export const pcdSchema = z.object({
     firstId: z.string(),
-    secondId: z.string(),
-    currentDist: z.number(),
-    minDist: z.number(),
-    timeToMinDistMs: z.number()
+    secondId: z.string()
 });
 
 export type Pcd = z.infer<typeof pcdSchema>;
 
 export const scenarioSchema = z.object({
-    view: viewSchema,
     boundaries: boundariesSchema,
     flights: flightSchema.array(),
     pcds: pcdSchema.array()


### PR DESCRIPTION
Implements the following feedback

> In general, ATCOs do not scroll outside their area. The scenario should be loaded and visible w/o scrolling.