### PR TITLE
Use local database on dev environment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+services:
+  postgres:
+    image: postgres
+    environment:
+      POSTGRES_PASSWORD: password
+    ports:
+      - '54320:5432'
+  pg_proxy:
+    image: ghcr.io/neondatabase/wsproxy:latest
+    environment:
+      APPEND_PORT: 'postgres:5432'
+      ALLOW_ADDR_REGEX: '.*'
+      LOG_TRAFFIC: 'true'
+    ports:
+      - '54330:80'
+    depends_on:
+      - postgres

--- a/lib/db/index.ts
+++ b/lib/db/index.ts
@@ -1,6 +1,14 @@
 import '~/loadenv';
 import { drizzle } from 'drizzle-orm/vercel-postgres';
-import { sql } from '@vercel/postgres';
 import * as schema from './schema';
+import { neonConfig } from '@neondatabase/serverless';
+import { sql } from '@vercel/postgres';
+
+if (process.env.VERCEL_ENV === 'development') {
+    neonConfig.wsProxy = (host) => `${host}:54330/v1`;
+    neonConfig.useSecureWebSocket = false;
+    neonConfig.pipelineTLS = false;
+    neonConfig.pipelineConnect = false;
+}
 
 export const db = drizzle(sql, { schema });

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,8 @@
                 "mapbox-gl": "^3.9.2",
                 "next": "^15.1.3",
                 "next-themes": "^0.4.4",
+                "pg": "^8.13.1",
+                "postgres": "^3.4.5",
                 "posthog-js": "^1.203.3",
                 "react": "^19.0.0",
                 "react-dom": "^19.0.0",
@@ -46,6 +48,7 @@
                 "@eslint/eslintrc": "^3",
                 "@types/luxon": "^3.4.2",
                 "@types/node": "^22",
+                "@types/pg": "^8.11.10",
                 "@types/react": "^19",
                 "@types/react-dom": "^19",
                 "drizzle-kit": "^0.30.1",
@@ -1889,6 +1892,19 @@
             "peer": true,
             "dependencies": {
                 "@types/pg": "8.11.6"
+            }
+        },
+        "node_modules/@neondatabase/serverless/node_modules/@types/pg": {
+            "version": "8.11.6",
+            "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.11.6.tgz",
+            "integrity": "sha512-/2WmmBXHLsfRqzfHW7BNZ8SbYzE8OSk7i3WjFYvfgRHj7S1xj+16Je5fUKv3lVdVzk/zn9TXOqf+avFCFIE0yQ==",
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@types/node": "*",
+                "pg-protocol": "*",
+                "pg-types": "^4.0.1"
             }
         },
         "node_modules/@next/env": {
@@ -5352,9 +5368,10 @@
             "license": "MIT"
         },
         "node_modules/@types/pg": {
-            "version": "8.11.6",
-            "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.11.6.tgz",
-            "integrity": "sha512-/2WmmBXHLsfRqzfHW7BNZ8SbYzE8OSk7i3WjFYvfgRHj7S1xj+16Je5fUKv3lVdVzk/zn9TXOqf+avFCFIE0yQ==",
+            "version": "8.11.10",
+            "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.11.10.tgz",
+            "integrity": "sha512-LczQUW4dbOQzsH2RQ5qoeJ6qJPdrcM/DcMLoqWQkMLMsq83J5lAX3LXjdkWdpscFy67JSOWDnh7Ny/sPFykmkg==",
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "@types/node": "*",
@@ -5639,15 +5656,6 @@
             },
             "engines": {
                 "node": ">=18.14"
-            }
-        },
-        "node_modules/@vercel/postgres/node_modules/@neondatabase/serverless": {
-            "version": "0.9.5",
-            "resolved": "https://registry.npmjs.org/@neondatabase/serverless/-/serverless-0.9.5.tgz",
-            "integrity": "sha512-siFas6gItqv6wD/pZnvdu34wEqgG3nSE6zWZdq5j2DEsa+VvX8i/5HXJOo06qrw5axPXn+lGCxeR+NLaSPIXug==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/pg": "8.11.6"
             }
         },
         "node_modules/acorn": {
@@ -9751,6 +9759,46 @@
                 "pbf": "bin/pbf"
             }
         },
+        "node_modules/pg": {
+            "version": "8.13.1",
+            "resolved": "https://registry.npmjs.org/pg/-/pg-8.13.1.tgz",
+            "integrity": "sha512-OUir1A0rPNZlX//c7ksiu7crsGZTKSOXJPgtNiHGIlC9H0lO+NC6ZDYksSgBYY/thSWhnSRBv8w1lieNNGATNQ==",
+            "license": "MIT",
+            "dependencies": {
+                "pg-connection-string": "^2.7.0",
+                "pg-pool": "^3.7.0",
+                "pg-protocol": "^1.7.0",
+                "pg-types": "^2.1.0",
+                "pgpass": "1.x"
+            },
+            "engines": {
+                "node": ">= 8.0.0"
+            },
+            "optionalDependencies": {
+                "pg-cloudflare": "^1.1.1"
+            },
+            "peerDependencies": {
+                "pg-native": ">=3.0.1"
+            },
+            "peerDependenciesMeta": {
+                "pg-native": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/pg-cloudflare": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.1.1.tgz",
+            "integrity": "sha512-xWPagP/4B6BgFO+EKz3JONXv3YDgvkbVrGw2mTo3D6tVDQRh1e7cqVGvyR3BE+eQgAvx1XhW/iEASj4/jCWl3Q==",
+            "license": "MIT",
+            "optional": true
+        },
+        "node_modules/pg-connection-string": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.7.0.tgz",
+            "integrity": "sha512-PI2W9mv53rXJQEOb8xNR8lH7Hr+EKa6oJa38zsK0S/ky2er16ios1wLKhZyxzD7jUReiWokc9WK5nxSnC7W1TA==",
+            "license": "MIT"
+        },
         "node_modules/pg-int8": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
@@ -9767,6 +9815,15 @@
             "license": "ISC",
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/pg-pool": {
+            "version": "3.7.0",
+            "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.7.0.tgz",
+            "integrity": "sha512-ZOBQForurqh4zZWjrgSwwAtzJ7QiRX0ovFkZr2klsen3Nm0aoh33Ls0fzfv3imeH/nw/O27cjdz5kzYJfeGp/g==",
+            "license": "MIT",
+            "peerDependencies": {
+                "pg": ">=8.0"
             }
         },
         "node_modules/pg-protocol": {
@@ -9791,6 +9848,70 @@
             },
             "engines": {
                 "node": ">=10"
+            }
+        },
+        "node_modules/pg/node_modules/pg-types": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+            "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+            "license": "MIT",
+            "dependencies": {
+                "pg-int8": "1.0.1",
+                "postgres-array": "~2.0.0",
+                "postgres-bytea": "~1.0.0",
+                "postgres-date": "~1.0.4",
+                "postgres-interval": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/pg/node_modules/postgres-array": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+            "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/pg/node_modules/postgres-bytea": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+            "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/pg/node_modules/postgres-date": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+            "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/pg/node_modules/postgres-interval": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+            "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+            "license": "MIT",
+            "dependencies": {
+                "xtend": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/pgpass": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+            "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+            "license": "MIT",
+            "dependencies": {
+                "split2": "^4.1.0"
             }
         },
         "node_modules/picocolors": {
@@ -10012,6 +10133,19 @@
             "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
             "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
             "license": "MIT"
+        },
+        "node_modules/postgres": {
+            "version": "3.4.5",
+            "resolved": "https://registry.npmjs.org/postgres/-/postgres-3.4.5.tgz",
+            "integrity": "sha512-cDWgoah1Gez9rN3H4165peY9qfpEo+SA61oQv65O3cRUE1pOEoJWwddwcqKE8XZYjbblOJlYDlLV4h67HrEVDg==",
+            "license": "Unlicense",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "type": "individual",
+                "url": "https://github.com/sponsors/porsager"
+            }
         },
         "node_modules/postgres-array": {
             "version": "3.0.2",
@@ -11069,6 +11203,15 @@
             },
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/split2": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+            "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+            "license": "ISC",
+            "engines": {
+                "node": ">= 10.x"
             }
         },
         "node_modules/stable-hash": {
@@ -12199,6 +12342,15 @@
                 "utf-8-validate": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/xtend": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+            "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.4"
             }
         },
         "node_modules/yaml": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
         "mapbox-gl": "^3.9.2",
         "next": "^15.1.3",
         "next-themes": "^0.4.4",
+        "pg": "^8.13.1",
+        "postgres": "^3.4.5",
         "posthog-js": "^1.203.3",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -53,6 +55,7 @@
         "@eslint/eslintrc": "^3",
         "@types/luxon": "^3.4.2",
         "@types/node": "^22",
+        "@types/pg": "^8.11.10",
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "drizzle-kit": "^0.30.1",
@@ -67,5 +70,8 @@
         "sass": "^1.83.1",
         "tailwindcss": "^3.4.17",
         "typescript": "^5"
+    },
+    "overrides": {
+        "@neondatabase/serverless": "0.10.4"
     }
 }


### PR DESCRIPTION
This requires an update on `.env` replace `POSTGRES_URL` and add `VERCEL_ENV` like so

```bash
VERCEL_ENV=development
POSTGRES_URL=postgresql://postgres:password@localhost:54320/postgres
```

To use it, `docker compose up -d` and then `npm run dev` 

From there, most likely run `npx drizzle-kit push` to update the database schema.

Finally, to feed the database with some data go to https://tango5-aero.vercel.app/backstage/scenarios and download some scenarios as JSON, then go to http://localhost:3000/backstage/scenarios and upload them 

NOTE: This process of pushing the schema and seeding the database will be automated soon (c)
