### PR TITLE
Run db migrations on CI

### DIFF
--- a/drizzle/0000_wealthy_toro.sql
+++ b/drizzle/0000_wealthy_toro.sql
@@ -1,0 +1,19 @@
+CREATE TABLE "scenarios" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"data" text NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "usergames" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"scenario_id" integer NOT NULL,
+	"play_time" interval NOT NULL,
+	"success" boolean NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "users" (
+	"id" text PRIMARY KEY NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "usergames" ADD CONSTRAINT "usergames_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "usergames" ADD CONSTRAINT "usergames_scenario_id_scenarios_id_fk" FOREIGN KEY ("scenario_id") REFERENCES "public"."scenarios"("id") ON DELETE cascade ON UPDATE no action;

--- a/drizzle/meta/0000_snapshot.json
+++ b/drizzle/meta/0000_snapshot.json
@@ -1,0 +1,125 @@
+{
+    "id": "93ebea2d-a938-4b59-b59e-2dedafa7c7e4",
+    "prevId": "00000000-0000-0000-0000-000000000000",
+    "version": "7",
+    "dialect": "postgresql",
+    "tables": {
+        "public.scenarios": {
+            "name": "scenarios",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "serial",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "data": {
+                    "name": "data",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.usergames": {
+            "name": "usergames",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "serial",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "user_id": {
+                    "name": "user_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "scenario_id": {
+                    "name": "scenario_id",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "play_time": {
+                    "name": "play_time",
+                    "type": "interval",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "success": {
+                    "name": "success",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": true
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {
+                "usergames_user_id_users_id_fk": {
+                    "name": "usergames_user_id_users_id_fk",
+                    "tableFrom": "usergames",
+                    "tableTo": "users",
+                    "columnsFrom": ["user_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                },
+                "usergames_scenario_id_scenarios_id_fk": {
+                    "name": "usergames_scenario_id_scenarios_id_fk",
+                    "tableFrom": "usergames",
+                    "tableTo": "scenarios",
+                    "columnsFrom": ["scenario_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.users": {
+            "name": "users",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        }
+    },
+    "enums": {},
+    "schemas": {},
+    "sequences": {},
+    "roles": {},
+    "policies": {},
+    "views": {},
+    "_meta": {
+        "columns": {},
+        "schemas": {},
+        "tables": {}
+    }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+    "version": "7",
+    "dialect": "postgresql",
+    "entries": [
+        {
+            "idx": 0,
+            "version": "7",
+            "when": 1736963227427,
+            "tag": "0000_wealthy_toro",
+            "breakpoints": true
+        }
+    ]
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "scripts": {
         "drizzle": "drizzle-kit",
         "dev": "next dev --turbopack",
-        "build": "next build",
+        "build": "next build && drizzle-kit migrate",
         "start": "next start",
         "types": "tsc",
         "lint": "next lint",


### PR DESCRIPTION
After a lot of reading the docs and blog post I found what I think it is the easiest way to achieve the goal of run migrations automatically. 

The solution is basically add a `drizzle-kit migrate` step after `next build`. 

⚠️ ⚠️ ⚠️  This require we change the way we handle migrations; ⚠️ ⚠️ ⚠️  

Instead of go YOLO and do a `npx drizzle-kit push` **we need to commit the actual sql migration files**, this is achieved with `npx drizzle-kit generate` and applied with `npx drizzle-kit migrate`.


This is important because local development will be done with a local database, so the steps need to be done on the dev machines before pushing, or CI will fail miserably.

And now to make it more memorable I made this meme:

![9gs39u](https://github.com/user-attachments/assets/30bc2b2c-3445-41db-a031-9bec794624c5)

