### PR TITLE
Modified game logic as per spec

### DIFF
--- a/components/game/game.tsx
+++ b/components/game/game.tsx
@@ -103,17 +103,6 @@ const Game = (props: PropsWithoutRef<{ id: number; scenario: Scenario; nextUrl: 
         // update user selection pairs and clear current flight selection
         setSelectedPairs([...selectedPairs, pair]);
         setSelectedFlight(null);
-
-        // check if game should continue based on last player selection
-        const correct = props.scenario.pcds.some(
-            (pcd) =>
-                (pcd.firstId === pair[0] && pcd.secondId === pair[1]) ||
-                (pcd.firstId === pair[1] && pcd.secondId === pair[0])
-        );
-        if (!correct) {
-            setGameOver(true);
-            return;
-        }
     };
 
     return (

--- a/components/game/game.tsx
+++ b/components/game/game.tsx
@@ -66,7 +66,7 @@ const Game = (props: PropsWithoutRef<{ id: number; scenario: Scenario; nextUrl: 
     }, [props.scenario.pcds.length, selectedPairs.length]);
 
     const selectFlight = (id: string) => {
-        // if the game is over do not allow further interactions and open report again to hint the user
+        // if the game is over do not allow further interactions
         if (isGameOver) {
             return;
         }
@@ -76,20 +76,15 @@ const Game = (props: PropsWithoutRef<{ id: number; scenario: Scenario; nextUrl: 
         // this should never happen, fail silently
         if (!flight) return;
 
-        // avoid selecting the same flight two times on the same pair
-        if (selectedFlight === flight.id) {
-            return;
-        }
-
         // if there is no previous selection, just select current flight
         if (!selectedFlight) {
             setSelectedFlight(flight.id);
+            return;
+        }
 
-            // if flight is not on any pair, is game over
-            if (!props.scenario.pcds.some(({ firstId, secondId }) => firstId === flight.id || secondId === flight.id)) {
-                setGameOver(true);
-            }
-
+        // deselect the flight if it was already selected
+        if (selectedFlight === flight.id) {
+            setSelectedFlight(null);
             return;
         }
 

--- a/components/scenario/scenario-map.tsx
+++ b/components/scenario/scenario-map.tsx
@@ -156,11 +156,6 @@ type LayerProps = {
     isGameOver: boolean;
 };
 
-const colors = {
-    correct: '#779556',
-    fail: '#D45D08'
-};
-
 const Layers = (props: PropsWithChildren<LayerProps>) => {
     const { map: mapRef } = useMap();
 
@@ -240,14 +235,20 @@ const Layers = (props: PropsWithChildren<LayerProps>) => {
             <Layer
                 id={LayersIds.pcdLine}
                 type="line"
-                paint={{ 'line-color': ['case', ['boolean', ['get', 'correct'], true], colors.correct, colors.fail] }}
+                paint={{
+                    'line-color': ['case', ['boolean', ['get', 'isPcd'], true], '#D45D08', '#841212'],
+                    'line-dasharray': ['case', ['boolean', ['get', 'isPcd'], true], [1], [6, 4]]
+                }}
                 filter={['==', ['get', 'type'], GeometryTypes.pcdLink]}
                 beforeId={LayersIds.positionFill}
             />
             <Layer
                 id={LayersIds.pcdLabelFill}
                 type="fill"
-                paint={{ 'fill-opacity': 0 }}
+                paint={{
+                    'fill-opacity': 1,
+                    'fill-color': ['case', ['boolean', ['get', 'isPcd'], true], '#8BA863', '#841212']
+                }}
                 filter={['==', ['get', 'type'], GeometryTypes.pcdLabel]}
             />
             <Layer
@@ -262,7 +263,7 @@ const Layers = (props: PropsWithChildren<LayerProps>) => {
                     'text-size': ['get', 'fontSize'],
                     'text-rotation-alignment': 'viewport'
                 }}
-                paint={{ 'text-color': ['case', ['boolean', ['get', 'correct'], true], colors.correct, colors.fail] }}
+                paint={{ 'text-color': ['case', ['boolean', ['get', 'isPcd'], true], '#13151A', '#C9CDD0'] }}
             />
             <Layer
                 id={LayersIds.labelFill}

--- a/components/scenario/scenario-map.tsx
+++ b/components/scenario/scenario-map.tsx
@@ -222,7 +222,7 @@ const Layers = (props: PropsWithChildren<LayerProps>) => {
             <Layer
                 id={LayersIds.halo}
                 type="line"
-                paint={{ 'line-color': ['case', ['boolean', ['get', 'correct'], true], colors.correct, colors.fail] }}
+                paint={{ 'line-color': '#FFFFFF' }}
                 filter={['==', ['get', 'type'], GeometryTypes.halo]}
             />
             <Layer

--- a/lib/domain/geojson.ts
+++ b/lib/domain/geojson.ts
@@ -13,7 +13,9 @@ type Props =
               | typeof GeometryTypes.speedVector
               | typeof GeometryTypes.label
               | typeof GeometryTypes.labelLink
-              | typeof GeometryTypes.pcdLabel;
+              | typeof GeometryTypes.pcdLabel
+              | typeof GeometryTypes.halo
+              | typeof GeometryTypes.pcdLink;
       }
     | {
           ref: string;
@@ -23,8 +25,6 @@ type Props =
       }
     | {
           ref: string;
-          type: typeof GeometryTypes.halo | typeof GeometryTypes.pcdLink;
-          correct: boolean;
       }
     | {
           ref: string;
@@ -74,6 +74,7 @@ export function featureCollection(
     flights: Flight[],
     selectedFlight: string | null,
     selectedPairs: [string, string][],
+
     solutionPairs: [string, string][],
     reveal: boolean,
     scalingFactor: number,
@@ -166,42 +167,13 @@ export function featureCollection(
         const otherFlight = flights.find((flight) => flight.id === pair[1]);
 
         if (flight && otherFlight) {
-            collection.features.push(
-                circle([flight.longitudeDeg, flight.latitudeDeg], 5, {
-                    steps: 20,
-                    units: 'nauticalmiles',
-                    properties: {
-                        ref: flight.id,
-                        type: GeometryTypes.halo,
-                        correct: solutionPairs.some((pair) => pair.includes(flight.id))
-                    }
-                })
-            );
-
-            collection.features.push(
-                circle([otherFlight.longitudeDeg, otherFlight.latitudeDeg], 5, {
-                    steps: 20,
-                    units: 'nauticalmiles',
-                    properties: {
-                        ref: otherFlight.id,
-                        type: GeometryTypes.halo,
-                        correct: solutionPairs.some((pair) => pair.includes(otherFlight.id))
-                    }
-                })
-            );
-
             const id = flight < otherFlight ? `${flight.id}-${otherFlight.id}` : `${otherFlight.id}-${flight.id}`;
 
             collection.features.push({
                 type: 'Feature',
                 properties: {
                     ref: id,
-                    type: GeometryTypes.pcdLink,
-                    correct: solutionPairs.some(
-                        (pair) =>
-                            (pair[0] === flight.id && pair[1] === otherFlight.id) ||
-                            (pair[0] === otherFlight.id && pair[1] === flight.id)
-                    )
+                    type: GeometryTypes.pcdLink
                 },
                 geometry: {
                     type: 'LineString',

--- a/lib/domain/geojson.ts
+++ b/lib/domain/geojson.ts
@@ -5,6 +5,8 @@ import { Flight } from '~/lib/domain/flight';
 import { GeometryTypes } from '~/components/scenario/scenario-map';
 import { circle } from '@turf/turf';
 
+const MIN_DIS_THRESHOLD_NM = 9;
+
 type Props =
     | {
           ref: string;
@@ -13,9 +15,7 @@ type Props =
               | typeof GeometryTypes.speedVector
               | typeof GeometryTypes.label
               | typeof GeometryTypes.labelLink
-              | typeof GeometryTypes.pcdLabel
-              | typeof GeometryTypes.halo
-              | typeof GeometryTypes.pcdLink;
+              | typeof GeometryTypes.halo;
       }
     | {
           ref: string;
@@ -25,13 +25,16 @@ type Props =
       }
     | {
           ref: string;
+          type: typeof GeometryTypes.pcdLink | typeof GeometryTypes.pcdLabel;
+
+          isPcd: boolean;
       }
     | {
           ref: string;
           type: typeof GeometryTypes.pcdText;
           text: string;
           fontSize: number;
-          correct: boolean;
+          isPcd: boolean;
       };
 
 export function measureTextBBox(text: string, fontSize: number): { height: number; width: number } {
@@ -169,24 +172,15 @@ export function featureCollection(
         if (flight && otherFlight) {
             const id = flight < otherFlight ? `${flight.id}-${otherFlight.id}` : `${otherFlight.id}-${flight.id}`;
 
-            collection.features.push({
-                type: 'Feature',
-                properties: {
-                    ref: id,
-                    type: GeometryTypes.pcdLink
-                },
-                geometry: {
-                    type: 'LineString',
-                    coordinates: [
-                        [flight.longitudeDeg, flight.latitudeDeg],
-                        [otherFlight.longitudeDeg, otherFlight.latitudeDeg]
-                    ]
-                }
-            });
-
             const measure = flight.measureDistanceTo(otherFlight);
 
             if (!measure) continue;
+
+            console.log(measure);
+
+            const isPcd =
+                measure.currentDistanceNM <= MIN_DIS_THRESHOLD_NM ||
+                ('minimumDistanceNM' in measure ? measure.minimumDistanceNM <= MIN_DIS_THRESHOLD_NM : false);
 
             const minimumDistanceText =
                 'minimumDistanceNM' in measure && 'timeToMinimumDistanceMs' in measure
@@ -215,7 +209,24 @@ export function featureCollection(
                 type: 'Feature',
                 properties: {
                     ref: id,
-                    type: GeometryTypes.pcdLabel
+                    type: GeometryTypes.pcdLink,
+                    isPcd
+                },
+                geometry: {
+                    type: 'LineString',
+                    coordinates: [
+                        [flight.longitudeDeg, flight.latitudeDeg],
+                        [otherFlight.longitudeDeg, otherFlight.latitudeDeg]
+                    ]
+                }
+            });
+
+            collection.features.push({
+                type: 'Feature',
+                properties: {
+                    ref: id,
+                    type: GeometryTypes.pcdLabel,
+                    isPcd
                 },
                 geometry: {
                     type: 'Polygon',
@@ -230,11 +241,7 @@ export function featureCollection(
                     type: GeometryTypes.pcdText,
                     text,
                     fontSize,
-                    correct: solutionPairs.some(
-                        (pair) =>
-                            (pair[0] === flight.id && pair[1] === otherFlight.id) ||
-                            (pair[0] === otherFlight.id && pair[1] === flight.id)
-                    )
+                    isPcd
                 },
                 geometry: {
                     type: 'Point',

--- a/lib/domain/geojson.ts
+++ b/lib/domain/geojson.ts
@@ -192,14 +192,28 @@ export function featureCollection(
             const textSize = measureTextBBox(text, fontSize);
 
             const width = Math.max(1, textSize.width / 1.5);
-            const height = Math.max(1, textSize.height / 1.5);
+            const height = Math.max(1, textSize.height / 1.25);
 
-            const labelCenter = [
-                (flight.longitudeDeg + otherFlight.longitudeDeg) / 2,
-                (flight.latitudeDeg + otherFlight.latitudeDeg) / 2
-            ] as [number, number];
+            const flightViewSpace = project([flight.longitudeDeg, flight.latitudeDeg]);
+            const otherFlightViewSpace = project([otherFlight.longitudeDeg, otherFlight.latitudeDeg]);
 
-            const label = expand(project(labelCenter), width, height);
+            const flightsMidPoint = [
+                (flightViewSpace[0] + otherFlightViewSpace[0]) / 2,
+                (flightViewSpace[1] + otherFlightViewSpace[1]) / 2
+            ];
+
+            const ratio =
+                flightsMidPoint[1] !== 0
+                    ? (flightViewSpace[0] - otherFlightViewSpace[0]) / (flightViewSpace[1] - otherFlightViewSpace[1])
+                    : -1;
+
+            const labelCenter = (
+                ratio > 0
+                    ? [flightsMidPoint[0] + width, flightsMidPoint[1] - height]
+                    : [flightsMidPoint[0] - width, flightsMidPoint[1] - height]
+            ) as [number, number];
+
+            const label = expand(labelCenter, width, height);
 
             const coordinates = [label.map((point) => unproject(point))];
 
@@ -245,7 +259,7 @@ export function featureCollection(
                 },
                 geometry: {
                     type: 'Point',
-                    coordinates: labelCenter
+                    coordinates: unproject(labelCenter)
                 }
             });
         }


### PR DESCRIPTION
closes #75 

There are a few changes:
- Selecting a single flight no longer ends a game, even if is wrong
- Selections are made in pairs, 
- The halo only appears temporarily when the first flight of a pair is selected.
- The first flight of a pair (halo) can be de-selected.
- But, once a pair is selected, it can not be de-selected anymore.
- Selecting the wrong pair does not end the game immediately,
- A number of pairs equal to the number of pcds must be selected, to end the game before the time runs out (still 30s).
- Solution is only revealed after all pairs (=number of pcds) are selected.
- Solutions are color-coded with a green label that indicates an actual PCD (regardless of user selection)
- User fails (not actual PCDs but user selected the pair) are indicated with a red label

⚠️ ⚠️ Until #74 is implemented the solutions will not always be 100% acurrated ⚠️ ⚠️   
