### PR TITLE
Fix duplicated games played

### DIFF
--- a/drizzle/0001_fat_pretty_boy.sql
+++ b/drizzle/0001_fat_pretty_boy.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "usergames" ADD CONSTRAINT "unique_id" UNIQUE("user_id","scenario_id");

--- a/drizzle/0001_fat_pretty_boy.sql
+++ b/drizzle/0001_fat_pretty_boy.sql
@@ -1,1 +1,2 @@
+TRUNCATE TABLE "usergames";
 ALTER TABLE "usergames" ADD CONSTRAINT "unique_id" UNIQUE("user_id","scenario_id");

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,131 @@
+{
+    "id": "55284aa3-6263-4ec0-9da9-722706cabfee",
+    "prevId": "93ebea2d-a938-4b59-b59e-2dedafa7c7e4",
+    "version": "7",
+    "dialect": "postgresql",
+    "tables": {
+        "public.scenarios": {
+            "name": "scenarios",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "serial",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "data": {
+                    "name": "data",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.usergames": {
+            "name": "usergames",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "serial",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "user_id": {
+                    "name": "user_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "scenario_id": {
+                    "name": "scenario_id",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "play_time": {
+                    "name": "play_time",
+                    "type": "interval",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "success": {
+                    "name": "success",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": true
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {
+                "usergames_user_id_users_id_fk": {
+                    "name": "usergames_user_id_users_id_fk",
+                    "tableFrom": "usergames",
+                    "tableTo": "users",
+                    "columnsFrom": ["user_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                },
+                "usergames_scenario_id_scenarios_id_fk": {
+                    "name": "usergames_scenario_id_scenarios_id_fk",
+                    "tableFrom": "usergames",
+                    "tableTo": "scenarios",
+                    "columnsFrom": ["scenario_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {
+                "unique_id": {
+                    "name": "unique_id",
+                    "nullsNotDistinct": false,
+                    "columns": ["user_id", "scenario_id"]
+                }
+            },
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.users": {
+            "name": "users",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        }
+    },
+    "enums": {},
+    "schemas": {},
+    "sequences": {},
+    "roles": {},
+    "policies": {},
+    "views": {},
+    "_meta": {
+        "columns": {},
+        "schemas": {},
+        "tables": {}
+    }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
             "when": 1736963227427,
             "tag": "0000_wealthy_toro",
             "breakpoints": true
+        },
+        {
+            "idx": 1,
+            "version": "7",
+            "when": 1737539781425,
+            "tag": "0001_fat_pretty_boy",
+            "breakpoints": true
         }
     ]
 }

--- a/lib/db/queries/usergames.ts
+++ b/lib/db/queries/usergames.ts
@@ -3,7 +3,11 @@ import { db } from '~/lib/db';
 import { UserGameInsert, UserGamesTable } from '~/lib/db/schema';
 
 export const writeUserGame = async (userGame: UserGameInsert) => {
-    return await db.insert(UserGamesTable).values(userGame).onConflictDoNothing().returning();
+    return await db
+        .insert(UserGamesTable)
+        .values(userGame)
+        .onConflictDoNothing({ target: [UserGamesTable.userId, UserGamesTable.scenarioId] })
+        .returning();
 };
 
 export const getUserGames = async (userId?: string) => {

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -1,4 +1,4 @@
-import { boolean, integer, interval, pgTable, serial, text } from 'drizzle-orm/pg-core';
+import { boolean, integer, interval, pgTable, serial, text, unique } from 'drizzle-orm/pg-core';
 import { InferInsertModel, InferSelectModel } from 'drizzle-orm/table';
 
 export const ScenariosTable = pgTable('scenarios', {
@@ -12,16 +12,22 @@ export const UsersTable = pgTable('users', {
 });
 export type UserSelect = InferSelectModel<typeof UsersTable>;
 
-export const UserGamesTable = pgTable('usergames', {
-    id: serial('id').primaryKey(),
-    userId: text('user_id')
-        .references(() => UsersTable.id, { onDelete: 'cascade' })
-        .notNull(),
-    scenarioId: integer('scenario_id')
-        .references(() => ScenariosTable.id, { onDelete: 'cascade' })
-        .notNull(),
-    playTime: interval('play_time').notNull(),
-    success: boolean('success').notNull()
-});
+export const UserGamesTable = pgTable(
+    'usergames',
+    {
+        id: serial('id').primaryKey(),
+        userId: text('user_id')
+            .references(() => UsersTable.id, { onDelete: 'cascade' })
+            .notNull(),
+        scenarioId: integer('scenario_id')
+            .references(() => ScenariosTable.id, { onDelete: 'cascade' })
+            .notNull(),
+        playTime: interval('play_time').notNull(),
+        success: boolean('success').notNull()
+    },
+    (t) => ({
+        unique: unique('unique_id').on(t.userId, t.scenarioId)
+    })
+);
 export type UserGameInsert = InferInsertModel<typeof UserGamesTable>;
 export type UserGameSelect = InferSelectModel<typeof UserGamesTable>;

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -25,9 +25,7 @@ export const UserGamesTable = pgTable(
         playTime: interval('play_time').notNull(),
         success: boolean('success').notNull()
     },
-    (t) => ({
-        unique: unique('unique_id').on(t.userId, t.scenarioId)
-    })
+    (t) => [unique('unique_id').on(t.userId, t.scenarioId)]
 );
 export type UserGameInsert = InferInsertModel<typeof UserGamesTable>;
 export type UserGameSelect = InferSelectModel<typeof UserGamesTable>;

--- a/lib/db/tools/seed.ts
+++ b/lib/db/tools/seed.ts
@@ -18,7 +18,10 @@ async function main() {
     console.log('🌱 Seeding database...');
     await seed(db, schema).refine((f) => ({
         UsersTable: {
-            count: 5
+            count: 5,
+            with: {
+                UserGamesTable: 1
+            }
         },
         ScenariosTable: {
             count: 3,
@@ -34,7 +37,6 @@ async function main() {
             }
         },
         UserGamesTable: {
-            count: 10,
             columns: {
                 playTime: f.valuesFromArray({
                     values: times


### PR DESCRIPTION
# PR Description

Avoid save various games in the same scenario.

## How to try it

1. Execute `npm run drizzle migrate`.
2. Execute `npm run dev`.
3. Go and play some scenario two times.
4. Check if the registry in /backstage/games is only saved the first time that you played.

Checklist:

- [x] 🧐 it **works on my machine** (c)
- [x] 📋 added clear **instructions** to try it by a reviewer

## 📕 Changes made

- Add an unique id in the schema of UserGamesTable.
- Modify seed script to match the new schema.
- Modify writeUserGame query to cancel insert in conflict cases. 

## Checklist

- [ ] 📚 kept the **docs** updated
- [x] 📕 described the **changes** in this PR description

## Related issues

resolves #125 
