### PR TITLE
155 - Fix redirect when login to init page

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -18,7 +18,7 @@ export default async function Page() {
             <main className="relative z-20 flex h-screen flex-col items-center justify-center gap-6 p-6 md:p-10">
                 <WelcomeTango5Title />
                 <SignedOut>
-                    <SignIn routing="hash" forceRedirectUrl="" />
+                    <SignIn routing="hash" forceRedirectUrl={'/init'} />
                 </SignedOut>
             </main>
             <VideoBackground />


### PR DESCRIPTION
# PR Description

Fix the redirect when login. Instead / redirect to /init.

## How to try it

1. Login and check if it redirect to /init

Checklist:

- [x] 🧐 it **works on my machine** (c)
- [x] 📋 added clear **instructions** to try it by a reviewer

## 📕 Changes made

Force redirect to /init

## Checklist

- [ ] 📚 kept the **docs** updated
- [x] 📕 described the **changes** in this PR description

## Related issues

resolves #155 
