### PR TITLE
156 task organize types

### DIFF
--- a/components/scenario/scenario-release-date-dialog.tsx
+++ b/components/scenario/scenario-release-date-dialog.tsx
@@ -9,8 +9,9 @@ import { CalendarCog } from 'lucide-react';
 import { cacheTags } from '~/lib/constants';
 import { toast } from 'sonner';
 import { DatePicker } from '../ui/date-picker';
+import { ScenarioParsed } from '~/lib/types';
 
-export const ScenarioReleaseDateDialog = (props: PropsWithoutRef<{ id: number; releaseDate: string | undefined }>) => {
+export const ScenarioReleaseDateDialog = (props: PropsWithoutRef<Pick<ScenarioParsed, 'id' | 'releaseDate'>>) => {
     const [open, setOpen] = useState(false);
     const [date, setDate] = useState(props.releaseDate ? new Date(props.releaseDate) : undefined);
     const [state, action, pending] = useActionState(setScenarioReleaseDate, { message: '', error: false });

--- a/components/scenario/scenario-release-date-dialog.tsx
+++ b/components/scenario/scenario-release-date-dialog.tsx
@@ -10,6 +10,7 @@ import { cacheTags } from '~/lib/constants';
 import { toast } from 'sonner';
 import { DatePicker } from '../ui/date-picker';
 import { ScenarioParsed } from '~/lib/types';
+import { format } from 'date-fns';
 
 export const ScenarioReleaseDateDialog = (props: PropsWithoutRef<Pick<ScenarioParsed, 'id' | 'releaseDate'>>) => {
     const [open, setOpen] = useState(false);
@@ -28,7 +29,7 @@ export const ScenarioReleaseDateDialog = (props: PropsWithoutRef<Pick<ScenarioPa
 
     const setCurrentScenarioReleaseDate = () => {
         startTransition(async () => {
-            action({ id: props.id, releaseDate: date });
+            action({ id: props.id, releaseDate: date ? format(date, 'yyyy-MM-dd') : null });
             setOpen(false);
         });
     };

--- a/components/scenario/scenario-table.tsx
+++ b/components/scenario/scenario-table.tsx
@@ -6,15 +6,13 @@ import { type ScenarioData } from '~/lib/domain/scenario';
 import { ColumnDef } from '@tanstack/react-table';
 import { DataTable } from '~/components/ui/data-table';
 import { Download, PlayIcon } from 'lucide-react';
-import { ScenarioSelect } from '~/lib/db/schema';
 import { ScenarioReleaseDateDialog } from './scenario-release-date-dialog';
 import { usePagination } from '~/hooks/use-pagination';
 import { useTableApi } from '~/hooks/use-table-api';
 import { getScenariosPage } from '~/lib/actions';
+import { ScenarioParsed } from '~/lib/types';
 
-type ScenarioType = Omit<ScenarioSelect, 'data'> & { data: ScenarioData };
-
-export const columns: ColumnDef<ScenarioType>[] = [
+export const columns: ColumnDef<ScenarioParsed>[] = [
     {
         accessorKey: 'id',
         header: () => <div className="text-right">ID</div>

--- a/lib/actions/scenarios.ts
+++ b/lib/actions/scenarios.ts
@@ -5,6 +5,7 @@ import { ScenarioData, scenarioSchema } from '~/lib/domain/scenario';
 import { writeScenarios, updateScenarioReleaseDate } from '~/lib/db/queries';
 import { deleteScenario as deleteDBScenario, getScenariosPage as getDBScenariosPage } from '~/lib/db/queries';
 import { format } from 'date-fns';
+import { ScenarioParsed } from '~/lib/types';
 
 export async function createScenario(
     _prevState: ActionState,
@@ -47,7 +48,7 @@ export async function createScenario(
 
 export async function setScenarioReleaseDate(
     _prevState: ActionState,
-    payload: { id: number; releaseDate: Date | undefined }
+    payload: Pick<ScenarioParsed, 'id' | 'releaseDate'>
 ): Promise<ActionState> {
     const { id, releaseDate } = payload;
     const result = await updateScenarioReleaseDate(id, releaseDate);
@@ -64,7 +65,7 @@ export async function setScenarioReleaseDate(
     };
 }
 
-export async function deleteScenario(_prevState: ActionState, id: number): Promise<ActionState> {
+export async function deleteScenario(_prevState: ActionState, id: ScenarioParsed['id']): Promise<ActionState> {
     const result = await deleteDBScenario(id);
 
     if (result.length === 0) {

--- a/lib/actions/usergames.ts
+++ b/lib/actions/usergames.ts
@@ -9,10 +9,14 @@ import {
     deleteUserGames,
     getUserGamesPage as getDBUserGamesPage
 } from '~/lib/db/queries';
-import { UserGameInsert } from '~/lib/types';
+import { UserGameInsert, UserGameSelect } from '~/lib/types';
 import { ActionState } from '.';
 
-export async function completeUserGame(scenarioId: number, playTimeMs: number, success: boolean) {
+export async function completeUserGame(
+    scenarioId: UserGameInsert['scenarioId'],
+    playTimeMs: number,
+    success: UserGameInsert['success']
+) {
     const user = await currentUser();
 
     if (!user) {
@@ -35,7 +39,7 @@ export async function completeUserGame(scenarioId: number, playTimeMs: number, s
     await writeUserGame(userGame);
 }
 
-export async function deleteUserGame(_prevState: ActionState, id: number): Promise<ActionState> {
+export async function deleteUserGame(_prevState: ActionState, id: UserGameSelect['id']): Promise<ActionState> {
     const res = await deleteDBUserGame(id);
 
     if (res.length === 0) {
@@ -45,7 +49,10 @@ export async function deleteUserGame(_prevState: ActionState, id: number): Promi
     return { message: `UserGame #${id} deleted`, error: false };
 }
 
-export async function resetUserProgress(_prevState: ActionState, userId: string): Promise<ActionState> {
+export async function resetUserProgress(
+    _prevState: ActionState,
+    userId: UserGameInsert['userId']
+): Promise<ActionState> {
     try {
         await deleteUserGames(userId);
     } catch {

--- a/lib/actions/usergames.ts
+++ b/lib/actions/usergames.ts
@@ -9,7 +9,7 @@ import {
     deleteUserGames,
     getUserGamesPage as getDBUserGamesPage
 } from '~/lib/db/queries';
-import { UserGameInsert } from '~/lib/db/schema';
+import { UserGameInsert } from '~/lib/types';
 import { ActionState } from '.';
 
 export async function completeUserGame(scenarioId: number, playTimeMs: number, success: boolean) {

--- a/lib/db/queries/usergames.ts
+++ b/lib/db/queries/usergames.ts
@@ -1,7 +1,7 @@
 import { count, eq } from 'drizzle-orm';
 import { db } from '~/lib/db';
 import { UserGamesTable } from '~/lib/db/schema';
-import { UserGameInsert } from '~/lib/types';
+import { UserGameInsert, UserGameSelect } from '~/lib/types';
 
 export const writeUserGame = async (userGame: UserGameInsert) => {
     return await db
@@ -11,7 +11,7 @@ export const writeUserGame = async (userGame: UserGameInsert) => {
         .returning();
 };
 
-export const getUserGames = async (userId?: string) => {
+export const getUserGames = async (userId?: UserGameInsert['userId']) => {
     const query = db.select().from(UserGamesTable);
 
     if (userId) {
@@ -21,11 +21,11 @@ export const getUserGames = async (userId?: string) => {
     return await query.execute();
 };
 
-export const deleteUserGame = async (id: number) => {
+export const deleteUserGame = async (id: UserGameSelect['id']) => {
     return await db.delete(UserGamesTable).where(eq(UserGamesTable.id, id)).returning();
 };
 
-export const deleteUserGames = async (userId: string) => {
+export const deleteUserGames = async (userId: UserGameInsert['userId']) => {
     return await db.delete(UserGamesTable).where(eq(UserGamesTable.userId, userId)).returning();
 };
 

--- a/lib/db/queries/usergames.ts
+++ b/lib/db/queries/usergames.ts
@@ -1,6 +1,7 @@
 import { count, eq } from 'drizzle-orm';
 import { db } from '~/lib/db';
-import { UserGameInsert, UserGamesTable } from '~/lib/db/schema';
+import { UserGamesTable } from '~/lib/db/schema';
+import { UserGameInsert } from '~/lib/types';
 
 export const writeUserGame = async (userGame: UserGameInsert) => {
     return await db

--- a/lib/db/queries/users.ts
+++ b/lib/db/queries/users.ts
@@ -1,6 +1,7 @@
 import { count } from 'drizzle-orm';
 import { db } from '~/lib/db';
-import { UserSelect, UsersTable } from '~/lib/db/schema';
+import { UsersTable } from '~/lib/db/schema';
+import { UserSelect } from '~/lib/types';
 
 export const getUser = async (id: string) => {
     const res = await db.query.UsersTable.findFirst({ where: (user, { eq }) => eq(user.id, id) });

--- a/lib/db/queries/users.ts
+++ b/lib/db/queries/users.ts
@@ -3,7 +3,7 @@ import { db } from '~/lib/db';
 import { UsersTable } from '~/lib/db/schema';
 import { UserSelect } from '~/lib/types';
 
-export const getUser = async (id: string) => {
+export const getUser = async (id: UserSelect['id']) => {
     const res = await db.query.UsersTable.findFirst({ where: (user, { eq }) => eq(user.id, id) });
     return res;
 };

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -1,17 +1,13 @@
 import { boolean, date, integer, interval, pgTable, serial, text, unique } from 'drizzle-orm/pg-core';
-import { InferInsertModel, InferSelectModel } from 'drizzle-orm/table';
 
 export const ScenariosTable = pgTable('scenarios', {
     id: serial('id').primaryKey(),
     data: text('data').notNull(),
     releaseDate: date('release_date')
 });
-export type ScenarioSelect = InferSelectModel<typeof ScenariosTable>;
-
 export const UsersTable = pgTable('users', {
     id: text('id').primaryKey()
 });
-export type UserSelect = InferSelectModel<typeof UsersTable>;
 
 export const UserGamesTable = pgTable(
     'usergames',
@@ -28,5 +24,3 @@ export const UserGamesTable = pgTable(
     },
     (t) => [unique('unique_id').on(t.userId, t.scenarioId)]
 );
-export type UserGameInsert = InferInsertModel<typeof UserGamesTable>;
-export type UserGameSelect = InferSelectModel<typeof UserGamesTable>;

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -1,0 +1,10 @@
+import { InferSelectModel, InferInsertModel } from 'drizzle-orm/table';
+import { ScenariosTable, UserGamesTable, UsersTable } from './db/schema';
+import { ScenarioData } from './domain/scenario';
+
+type ScenarioSelect = InferSelectModel<typeof ScenariosTable>;
+
+export type ScenarioParsed = Omit<ScenarioSelect, 'data'> & { data: ScenarioData };
+
+export type UserGameInsert = InferInsertModel<typeof UserGamesTable>;
+export type UserSelect = InferSelectModel<typeof UsersTable>;

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -7,4 +7,5 @@ type ScenarioSelect = InferSelectModel<typeof ScenariosTable>;
 export type ScenarioParsed = Omit<ScenarioSelect, 'data'> & { data: ScenarioData };
 
 export type UserGameInsert = InferInsertModel<typeof UserGamesTable>;
+export type UserGameSelect = InferSelectModel<typeof UserGamesTable>;
 export type UserSelect = InferSelectModel<typeof UsersTable>;


### PR DESCRIPTION
# PR Description

<!-- Explain the goal of the PR -->

Organize main type definitions across the application

## How to try it

<!-- Instructions so that how a reviewer can try this locally
     Example:

     1. Navigate to the changed page
     1. Perform whatever action is required
     1. Validate that the output/user experience is as expected
-->

\-

Checklist:

- [ ] 🧐 it **works on my machine** (c)
- [ ] 📋 added clear **instructions** to try it by a reviewer

## 📕 Changes made

<!-- Reviewing a PR without context is frustrating and
     (a pointless) time consuming...

     Be a nice contributor and take time to explain
     what files changed, what were you trying to achieve, why?
     explain yourself. The more you write here, the better. -->

- Created a new file for types (`/lib/types.d.ts`) and move the main entity types there
- Link the params of server actions and queries to those entity types. That way we have them linked to the table definitions and will change automatically when the schema does.

## Checklist

- [ ] 📚 kept the **docs** updated
- [ ] 📕 described the **changes** in this PR description

## Related issues

<!-- List of issues resolved/canceled as a result of this PR
resolves #
fixes #
closes #
-->

resolves #156 
