### PR TITLE
Only display current user games in the summary table

### DIFF
--- a/app/(game)/games/page.tsx
+++ b/app/(game)/games/page.tsx
@@ -33,7 +33,7 @@ export default async function Page() {
                 <h3 className="text-xl">{`Keep playing to complete ${unplayedScenarios.length} remaining scenarios`}</h3>
             )}
 
-            <UserGamesTable allowDeleteGames={false} />
+            <UserGamesTable adminAccess={false} />
             <div className="flex flex-row gap-2">
                 <Button disabled={unplayedScenarios.length === 0} variant="outline">
                     <Link href="/play">Continue</Link>

--- a/app/backstage/games/page.tsx
+++ b/app/backstage/games/page.tsx
@@ -5,7 +5,7 @@ export default async function App() {
         <main className="flex flex-col items-center justify-center gap-6 p-6 md:p-10">
             <div>
                 <h3>Games by User</h3>
-                <UserGamesTable allowDeleteGames={true} />
+                <UserGamesTable adminAccess={true} />
             </div>
         </main>
     );

--- a/components/users/usergames-table.tsx
+++ b/components/users/usergames-table.tsx
@@ -5,7 +5,7 @@ import { DataTable } from '~/components/ui/data-table';
 import { PropsWithoutRef } from 'react';
 import { UserGameDeleteDialog } from '~/components/user-game/usergame-delete-dialog';
 import { usePagination } from '~/hooks/use-pagination';
-import { getUserGamesPage } from '~/lib/actions';
+import { getCurrentUserGamesPage, getUserGamesPage } from '~/lib/actions';
 import { useTableApi } from '~/hooks/use-table-api';
 
 type UserGameRow = {
@@ -17,7 +17,7 @@ type UserGameRow = {
 };
 
 type UserGamesTableProps = {
-    allowDeleteGames: boolean;
+    adminAccess: boolean;
 };
 
 export const userColumns: ColumnDef<UserGameRow>[] = [
@@ -88,7 +88,11 @@ export const adminColumns: ColumnDef<UserGameRow>[] = [
 export const UserGamesTable = (props: PropsWithoutRef<UserGamesTableProps>) => {
     const { pagination, onPaginationChange, limit, offset } = usePagination();
 
-    const { data, rowCount, loading } = useTableApi(getUserGamesPage, limit, offset);
+    const { data, rowCount, loading } = useTableApi(
+        props.adminAccess ? getUserGamesPage : getCurrentUserGamesPage,
+        limit,
+        offset
+    );
 
     return (
         <DataTable
@@ -97,7 +101,7 @@ export const UserGamesTable = (props: PropsWithoutRef<UserGamesTableProps>) => {
             loading={loading}
             onPaginationChange={onPaginationChange}
             pagination={pagination}
-            columns={props.allowDeleteGames ? adminColumns : userColumns}
+            columns={props.adminAccess ? adminColumns : userColumns}
             initialState={{ columnVisibility: { data: false } }}
         />
     );

--- a/hooks/use-table-api.ts
+++ b/hooks/use-table-api.ts
@@ -22,7 +22,7 @@ export function useTableApi<TRecord>(
             setRowCount(count);
             setLoading(false);
         });
-    }, [limit, offset, setData, setLoading]);
+    }, [limit, offset, action, setData, setLoading]);
 
     return { data, rowCount, loading };
 }

--- a/lib/actions/usergames.ts
+++ b/lib/actions/usergames.ts
@@ -7,7 +7,8 @@ import {
     deleteUserGame as deleteDBUserGame,
     writeUserGame,
     deleteUserGames,
-    getUserGamesPage as getDBUserGamesPage
+    getUserGamesPage as getDBUserGamesPage,
+    getCurrentUserGamesPage as getDBCurrentUserGamesPage
 } from '~/lib/db/queries';
 import { UserGameInsert } from '~/lib/db/schema';
 import { ActionState } from '.';
@@ -57,4 +58,8 @@ export async function resetUserProgress(_prevState: ActionState, userId: string)
 
 export async function getUserGamesPage(pageIndex: number, pageSize: number) {
     return await getDBUserGamesPage(pageIndex, pageSize);
+}
+
+export async function getCurrentUserGamesPage(pageIndex: number, pageSize: number) {
+    return await getDBCurrentUserGamesPage(pageIndex, pageSize);
 }

--- a/lib/db/queries/usergames.ts
+++ b/lib/db/queries/usergames.ts
@@ -1,3 +1,4 @@
+import { currentUser } from '@clerk/nextjs/server';
 import { count, eq } from 'drizzle-orm';
 import { db } from '~/lib/db';
 import { UserGameInsert, UserGamesTable } from '~/lib/db/schema';
@@ -32,6 +33,34 @@ export const getUserGamesPage = async (pageIndex: number, pageSize: number) => {
     try {
         const total = await db.select({ value: count() }).from(UserGamesTable);
         const values = await db.select().from(UserGamesTable).limit(pageSize).offset(pageIndex);
+        return {
+            count: total[0]?.value,
+            values
+        };
+    } catch {
+        return { count: 0, values: [] };
+    }
+};
+
+export const getCurrentUserGamesPage = async (pageIndex: number, pageSize: number) => {
+    const user = await currentUser();
+
+    if (!user) {
+        return { count: 0, values: [] };
+    }
+
+    try {
+        const total = await db
+            .select({ value: count() })
+            .from(UserGamesTable)
+            .where(eq(UserGamesTable.userId, user.id));
+        const values = await db
+            .select()
+            .from(UserGamesTable)
+            .where(eq(UserGamesTable.userId, user.id))
+            .limit(pageSize)
+            .offset(pageIndex);
+
         return {
             count: total[0]?.value,
             values


### PR DESCRIPTION
# PR Description

<!-- Explain the goal of the PR -->

Instead of displaying the current user's results, the games summary table was showing all the `usergames` available in the database. This PR fixes it.

## How to try it

<!-- Instructions so that how a reviewer can try this locally
     Example:

     1. Navigate to the changed page
     1. Perform whatever action is required
     1. Validate that the output/user experience is as expected
-->

1. Go to  `/games` and check everything is working. Same for `/backstage/games`.
1. In the `/games` route, you should now only see the games associated to your user.
1. Make sure that is the case by comparing both tables or by inspecting the database

Checklist:

- [ ] 🧐 it **works on my machine** (c)
- [ ] 📋 added clear **instructions** to try it by a reviewer

## 📕 Changes made

<!-- Reviewing a PR without context is frustrating and
     (a pointless) time consuming...

     Be a nice contributor and take time to explain
     what files changed, what were you trying to achieve, why?
     explain yourself. The more you write here, the better. -->

- Create a new action `getCurrentUserGamesPage` which is used instead of `getUserGamesPage` in `/games` route.
- Rename prop of `<UserGamesTable />` component.
- Add missing dependency to `useEffect` in `useTableApi` hook

## Checklist

- [ ] 📚 kept the **docs** updated
- [ ] 📕 described the **changes** in this PR description

## Related issues

<!-- List of issues resolved/canceled as a result of this PR
resolves #
fixes #
closes #
-->

resolves #165
