### PR TITLE
173 - Move scale to the top left corner

### DIFF
--- a/components/scenario/scenario-map.tsx
+++ b/components/scenario/scenario-map.tsx
@@ -96,7 +96,7 @@ const ScaleMap = (props: PropsWithoutRef<{ latitude: number }>) => {
     if (!mapRef) return;
 
     return (
-        <div className={`fixed bottom-8 left-8 z-30`} style={{ width: `${width}px` }}>
+        <div className={`fixed left-60 top-7 z-30`} style={{ width: `${width}px` }}>
             <div className="text-center text-sm text-secondary dark:text-primary">5NM</div>
             <div className="h-[5px] w-full border-b-[1px] border-l-[1px] border-r-[1px] dark:border-primary"></div>
             <div className="h-1 w-full border-l-[1px] border-r-[1px] dark:border-primary"></div>


### PR DESCRIPTION
# PR Description

Moved scale to the top left corner, to the right of the countdown timer.

## How to try it

1. Open a scenario
1. Check that the scale appears near the countdown timer.

Checklist:

- [x] 🧐 it **works on my machine** (c)
- [x] 📋 added clear **instructions** to try it by a reviewer

## 📕 Changes made

- Changed position of the scale

## Checklist

- [ ] 📚 kept the **docs** updated
- [x] 📕 described the **changes** in this PR description

## Related issues

resolves #173
