### PR TITLE
174 Change way to calculate vertical movement

### DIFF
--- a/lib/domain/flight.ts
+++ b/lib/domain/flight.ts
@@ -55,8 +55,10 @@ export class Flight {
     get intentDisplay(): '↑' | '↓' | '' {
         if (this.selectedAltitudeFt === undefined || this.altitudeFt === undefined) return '';
 
-        if (this.selectedAltitudeFt - this.altitudeFt > 100) return '↑';
-        if (this.selectedAltitudeFt - this.altitudeFt < -100) return '↓';
+        const altitudeFtWithoutDecimals = Math.round(this.altitudeFt / 100);
+        const selectedAltitudeFtWithoutDecimals = Math.round(this.selectedAltitudeFt / 100);
+        if (selectedAltitudeFtWithoutDecimals > altitudeFtWithoutDecimals) return '↑';
+        if (selectedAltitudeFtWithoutDecimals < altitudeFtWithoutDecimals) return '↓';
 
         return '';
     }

--- a/lib/domain/flight.ts
+++ b/lib/domain/flight.ts
@@ -53,10 +53,10 @@ export class Flight {
     }
 
     get intentDisplay(): '↑' | '↓' | '' {
-        if (this.verticalSpeedFtpm === undefined) return '';
+        if (this.selectedAltitudeFt === undefined || this.altitudeFt === undefined) return '';
 
-        if (this.verticalSpeedFtpm >= 200) return '↑';
-        if (this.verticalSpeedFtpm <= -200) return '↓';
+        if (this.selectedAltitudeFt - this.altitudeFt > 100) return '↑';
+        if (this.selectedAltitudeFt - this.altitudeFt < -100) return '↓';
 
         return '';
     }


### PR DESCRIPTION
# PR Description

Instead of using the vertical speed to print the arrow, as the images are static now, we only take into account the current altitude and the selected altitude.

## How to try it

1. Open a scenario
1. Validate that all the arrows are correct

Checklist:

- [x] 🧐 it **works on my machine** (c)
- [ ] 📋 added clear **instructions** to try it by a reviewer

## 📕 Changes made

- Removed vertical speed ftpm check and replace it with the current and selected altitude
-

## Checklist

- [ ] 📚 kept the **docs** updated
- [x] 📕 described the **changes** in this PR description

## Related issues

resolves #174
