### PR TITLE
172 Change text when selected incorrect pair

### DIFF
--- a/lib/domain/geojson.ts
+++ b/lib/domain/geojson.ts
@@ -187,10 +187,10 @@ export function featureCollection(
                     break;
                 case pcd?.isSafe:
                     status = 'clear';
-                    statusText = 'GOOD TO GO';
+                    statusText = 'KEEP TRYING';
                     break;
                 default:
-                    statusText = 'GOOD TO GO';
+                    statusText = 'KEEP TRYING';
             }
 
             const text = `${currentDistanceNM.toFixed(1)}NM${pcd?.description ? `\r\n${pcd.description}` : ''}`;


### PR DESCRIPTION
# PR Description

Update text when selected a wrong pair as per requirements

## How to try it

1. Open a scenario
1. Choose a pair that is not a PCD
1. Validate that the text says 'KEEP TRYING' instead of 'GOOD TO GO'

Checklist:

- [x] 🧐 it **works on my machine** (c)
- [ ] 📋 added clear **instructions** to try it by a reviewer

## 📕 Changes made

- Alter text when a pair is not a PCD

## Checklist

- [ ] 📚 kept the **docs** updated
- [x] 📕 described the **changes** in this PR description

## Related issues

resolves #172
