### PR TITLE
197 Add remaining scenarios on the top right corner

### DIFF
--- a/app/(game)/play/[scenarioId]/page.tsx
+++ b/app/(game)/play/[scenarioId]/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from 'next/navigation';
-import { getScenario } from '~/lib/db/queries';
+import { getScenario, getUnplayedScenarios } from '~/lib/db/queries';
 import { Game } from '~/components/game/game';
+import { currentUser } from '@clerk/nextjs/server';
 
 export default async function Page({ params }: { params: Promise<{ scenarioId: number }> }) {
     const id = (await params).scenarioId;
@@ -10,5 +11,13 @@ export default async function Page({ params }: { params: Promise<{ scenarioId: n
 
     if (!scenario?.data) notFound();
 
-    return <Game id={id} scenarioData={scenario.data} nextUrl={'/play'} />;
+    const user = await currentUser();
+
+    if (!user) {
+        return <Game id={id} unplayedScenarios={undefined} scenarioData={scenario.data} nextUrl={'/play'} />;
+    }
+
+    const unplayedScenarios = (await getUnplayedScenarios(user.id)).length;
+
+    return <Game id={id} unplayedScenarios={unplayedScenarios} scenarioData={scenario.data} nextUrl={'/play'} />;
 }

--- a/app/(game)/play/[scenarioId]/page.tsx
+++ b/app/(game)/play/[scenarioId]/page.tsx
@@ -1,4 +1,4 @@
-import { notFound } from 'next/navigation';
+import { notFound, redirect } from 'next/navigation';
 import { getScenario, getUnplayedScenarios } from '~/lib/db/queries';
 import { Game } from '~/components/game/game';
 import { currentUser } from '@clerk/nextjs/server';
@@ -14,7 +14,7 @@ export default async function Page({ params }: { params: Promise<{ scenarioId: n
     const user = await currentUser();
 
     if (!user) {
-        return <Game id={id} unplayedScenarios={undefined} scenarioData={scenario.data} nextUrl={'/play'} />;
+        redirect('/');
     }
 
     const unplayedScenarios = (await getUnplayedScenarios(user.id)).length;

--- a/components/game/game.tsx
+++ b/components/game/game.tsx
@@ -121,7 +121,7 @@ const Game = (
                         running={!isGameOver}
                         onComplete={() => setGameOver(true)}
                     />
-                    <div className="fixed right-32 top-6 z-10 text-white text-opacity-50 dark:text-black">
+                    <div className="fixed right-32 top-6 z-10 select-none text-white/50">
                         Remaining scenarios: {props.unplayedScenarios}
                     </div>
                 </>

--- a/components/game/game.tsx
+++ b/components/game/game.tsx
@@ -17,7 +17,14 @@ const posthogEvents = {
     gameFinish: 'game_finish'
 };
 
-const Game = (props: PropsWithoutRef<{ id: number; scenarioData: ScenarioData; nextUrl: string }>) => {
+const Game = (
+    props: PropsWithoutRef<{
+        id: number;
+        unplayedScenarios: number | undefined;
+        scenarioData: ScenarioData;
+        nextUrl: string;
+    }>
+) => {
     const scenario = useMemo(() => new Scenario(props.scenarioData), [props.scenarioData]);
 
     // Game related state
@@ -114,6 +121,13 @@ const Game = (props: PropsWithoutRef<{ id: number; scenarioData: ScenarioData; n
                         running={!isGameOver}
                         onComplete={() => setGameOver(true)}
                     />
+                    {props.unplayedScenarios !== undefined && (
+                        <div className="fixed right-24 top-6 z-10">
+                            <Button disabled={true} onClick={() => {}} variant="map" size="lg">
+                                Remaining scenarios: {props.unplayedScenarios}
+                            </Button>
+                        </div>
+                    )}
                 </>
             )}
             <ScenarioMap

--- a/components/game/game.tsx
+++ b/components/game/game.tsx
@@ -20,7 +20,7 @@ const posthogEvents = {
 const Game = (
     props: PropsWithoutRef<{
         id: number;
-        unplayedScenarios: number | undefined;
+        unplayedScenarios: number;
         scenarioData: ScenarioData;
         nextUrl: string;
     }>
@@ -121,13 +121,9 @@ const Game = (
                         running={!isGameOver}
                         onComplete={() => setGameOver(true)}
                     />
-                    {props.unplayedScenarios !== undefined && (
-                        <div className="fixed right-24 top-6 z-10">
-                            <Button disabled={true} onClick={() => {}} variant="map" size="lg">
-                                Remaining scenarios: {props.unplayedScenarios}
-                            </Button>
-                        </div>
-                    )}
+                    <div className="fixed right-32 top-6 z-10 text-white text-opacity-50 dark:text-black">
+                        Remaining scenarios: {props.unplayedScenarios}
+                    </div>
                 </>
             )}
             <ScenarioMap


### PR DESCRIPTION
# PR Description

Add the number of remaining scenarios to be completed on the top right corner.

## How to try it

1. Open a scenario, the number with the text should appear on the top right corner

Checklist:

- [x] 🧐 it **works on my machine** (c)
- [ ] 📋 added clear **instructions** to try it by a reviewer

## 📕 Changes made

- Add number of remaining scenarios to the game
- Print number using a disabled button (to have the same look than the 'next' button, it might not be the best idea, if it's a very bad idea, please, reject the PR and I'll change it).

## Checklist

- [ ] 📚 kept the **docs** updated
- [x] 📕 described the **changes** in this PR description

## Related issues

resolves #197
