### PR TITLE
169 - Fade away wrong user pair selection

### DIFF
--- a/components/game/game.tsx
+++ b/components/game/game.tsx
@@ -11,11 +11,14 @@ import posthog from 'posthog-js';
 import { GameProgress } from './game-progress';
 import { GAME_TIMEOUT_MS } from '~/lib/constants';
 import { Scenario } from '~/lib/domain/scenario';
+import { Pcd } from '~/lib/domain/pcd';
 
 const posthogEvents = {
     gameStart: 'game_start',
     gameFinish: 'game_finish'
 };
+
+const TIME_TO_REMOVE_FAILED_PAIRS_MS = 5000;
 
 const Game = (props: PropsWithoutRef<{ id: number; scenarioData: ScenarioData; nextUrl: string }>) => {
     const scenario = useMemo(() => new Scenario(props.scenarioData), [props.scenarioData]);
@@ -25,6 +28,7 @@ const Game = (props: PropsWithoutRef<{ id: number; scenarioData: ScenarioData; n
     const [selectedPairs, setSelectedPairs] = useState<[string, string][]>([]);
     const [isMapReady, setIsMapReady] = useState(false);
     const [isGameOver, setGameOver] = useState(false);
+    const selectedPairsRef = useRef(selectedPairs);
 
     const gameStartTimeMs = useRef<number | undefined>(undefined);
 
@@ -58,6 +62,28 @@ const Game = (props: PropsWithoutRef<{ id: number; scenarioData: ScenarioData; n
             setGameOver(true);
         }
     }, [scenario, selectedPairs]);
+
+    useEffect(() => {
+        selectedPairsRef.current = selectedPairs;
+        const pairsToClean = selectedPairs.filter((pair) => isClear(pair));
+        if (pairsToClean.length > 0) {
+            setTimeout(() => {
+                setSelectedPairs(selectedPairsRef.current.filter((pair) => !pairsToClean.includes(pair)));
+            }, TIME_TO_REMOVE_FAILED_PAIRS_MS);
+        }
+    }, [selectedPairs]);
+
+    const isClear = (pair: [string, string]) => {
+        const pcd = scenario.pcds.find(
+            (pcd) =>
+                (pcd.firstFlight.id === pair[0] && pcd.secondFlight.id === pair[1]) ||
+                (pcd.firstFlight.id === pair[1] && pcd.secondFlight.id === pair[0])
+        );
+        return (
+            typeof pcd === 'undefined' ||
+            new Pcd(pcd.firstFlight, pcd.secondFlight, pcd.minDistanceNM, pcd.timeToMinDistanceMs).isSafe
+        );
+    };
 
     const selectFlight = (id: string) => {
         // if the game is over do not allow further interactions


### PR DESCRIPTION
# PR Description

Remove pair selection when wrong.

## How to try it

Play and select pairs of flights that are safe. Check if the pair is removed.

Checklist:

- [x] 🧐 it **works on my machine** (c)
- [x] 📋 added clear **instructions** to try it by a reviewer

## 📕 Changes made

- Add useEffect to control the wrong selection.

## Checklist

- [ ] 📚 kept the **docs** updated
- [x] 📕 described the **changes** in this PR description

## Related issues

resolves #169 
