### PR TITLE
170 bug make sure all the labels are inside of the view

### DIFF
--- a/components/scenario/scenario-map.tsx
+++ b/components/scenario/scenario-map.tsx
@@ -9,6 +9,7 @@ import { MapEvent, MapMouseEvent } from 'mapbox-gl';
 
 import 'mapbox-gl/dist/mapbox-gl.css';
 import { destination, point, Units } from '@turf/turf';
+import { BBox } from '~/lib/domain/geometry';
 
 type ScenarioMapProps = {
     style?: CSSProperties;
@@ -35,13 +36,15 @@ const ScenarioMap = (props: PropsWithChildren<ScenarioMapProps>) => {
         e.target.getCanvas().style.cursor = '';
     };
 
+    const scaledBoundaries = scaleBbox(props.scenario.boundaries);
+
     return (
         <MapProvider>
             <ScaleMap latitude={props.scenario.boundaries[3]} />
             <MapGL
                 id="map"
                 mapboxAccessToken={process.env.NEXT_PUBLIC_MAPBOX_TOKEN}
-                initialViewState={{ bounds: props.scenario.boundaries }}
+                initialViewState={{ bounds: scaledBoundaries }}
                 style={props.style}
                 mapStyle={process.env.NEXT_PUBLIC_MAPBOX_STYLE}
                 interactive={false}
@@ -155,7 +158,7 @@ const Layers = (props: PropsWithChildren<LayerProps>) => {
             return [point.lng, point.lat] as [number, number];
         };
 
-        const scalingFactor = props.zoom ** 2;
+        const scalingFactor = props.zoom ** 2.1;
 
         const computedCollection = featureCollection(
             props.scenario,
@@ -323,5 +326,17 @@ const LayersIds = {
     labelText: 'labels-text',
     labelAnchor: 'label-anchor'
 } as const;
+
+const scaleBbox = (boundaries: BBox): BBox => {
+    const estimatedPaddingX = 0.5;
+    const estimatedPaddingY = 0.7;
+
+    return [
+        boundaries[0] - estimatedPaddingX,
+        boundaries[1] - estimatedPaddingY,
+        boundaries[2] + estimatedPaddingX,
+        boundaries[3] + estimatedPaddingY
+    ];
+};
 
 export { ScenarioMap, GeometryTypes };


### PR DESCRIPTION
# PR Description

In this PR, a magical number has been added to fix the issue where the aircraft's and pcd's lalbels were set out of screen's boundaries. I tried it in all my screens with different resolutions and seems to be correct.

## How to try it

<!-- Instructions so that how a reviewer can try this locally
     Example:

     1. Navigate to the changed page
     1. Perform whatever action is required
     1. Validate that the output/user experience is as expected
-->

1. Check that in the scenarios, all elements are fully visible

Checklist:

- [x] 🧐 it **works on my machine** (c)
- [x] 📋 added clear **instructions** to try it by a reviewer
- [ ] 📚 kept the **docs** updated
- [ ] 📕 described the **changes** in this PR description

## Related issues

<!-- List of issues resolved/canceled as a result of this PR
resolves #
fixes #
closes #
-->

resolves #170 
