### PR TITLE
209 Add scenario id on the bottom right corner

### DIFF
--- a/components/game/game.tsx
+++ b/components/game/game.tsx
@@ -137,6 +137,7 @@ const Game = (
                     {'NEXT'}
                 </Button>
             </div>
+            <div className="fixed bottom-1 right-72 z-10 mt-10 text-xs text-white/15">{props.id}</div>
             {isMapReady && (
                 <>
                     <GameProgress total={scenario.solution.length} progress={scenario.numberCorrect(selectedPairs)} />


### PR DESCRIPTION
# PR Description

Add scenario id slightly visible on the bottom right corner.

## How to try it

1. Start a game, the number should be on the bottom right corner right to the left of the mapbox copyright information.

Checklist:

- [x] 🧐 it **works on my machine** (c)
- [x] 📋 added clear **instructions** to try it by a reviewer

## 📕 Changes made

- Added a new label with the id of the scenario

## Checklist

- [ ] 📚 kept the **docs** updated
- [x] 📕 described the **changes** in this PR description

## Related issues

resolves #209
