### PR TITLE
Add best time to game performance stats

### DIFF
--- a/components/game/game-performance.tsx
+++ b/components/game/game-performance.tsx
@@ -1,7 +1,7 @@
-import { ComponentType, PropsWithoutRef } from 'react';
 import { CircleCheck, Clock3, LucideProps, StarIcon, XCircle } from 'lucide-react';
-import { Duration } from 'luxon';
+import { ComponentType, PropsWithoutRef } from 'react';
 import { getCurrentUserGamesPerformance } from '~/lib/actions';
+import { formatDuration } from '~/lib/utils';
 
 const GamePerformanceStat = (
     props: PropsWithoutRef<{ icon: ComponentType<LucideProps>; stat: string; description: string }>
@@ -28,8 +28,8 @@ export async function GamePerformance() {
 
     const { succeeded, total, playTimeAvg, playTimeMin, bestScenarioId } = performance;
 
-    const computedAverage = playTimeAvg ? Number(Duration.fromISOTime(playTimeAvg).toFormat('s.SSS')).toFixed(2) : '-';
-    const computedMin = playTimeMin ? Number(Duration.fromISOTime(playTimeMin).toFormat('s.SSS')).toFixed(2) : '-';
+    const computedAverage = playTimeAvg ? formatDuration(playTimeAvg) : '-';
+    const computedMin = playTimeMin ? formatDuration(playTimeMin) : '-';
 
     return (
         <section className="flex items-center justify-center gap-x-5">

--- a/components/game/game-performance.tsx
+++ b/components/game/game-performance.tsx
@@ -1,7 +1,7 @@
-import { PropsWithoutRef, ComponentType } from 'react';
-import { LucideProps, CircleCheck, XCircle, Clock3 } from 'lucide-react';
-import { getCurrentUserGamesPerformance } from '~/lib/actions';
+import { ComponentType, PropsWithoutRef } from 'react';
+import { CircleCheck, Clock3, LucideProps, StarIcon, XCircle } from 'lucide-react';
 import { Duration } from 'luxon';
+import { getCurrentUserGamesPerformance } from '~/lib/actions';
 
 const GamePerformanceStat = (
     props: PropsWithoutRef<{ icon: ComponentType<LucideProps>; stat: string; description: string }>
@@ -26,9 +26,10 @@ export async function GamePerformance() {
         return null;
     }
 
-    const { succeeded, total, playTimeAvg } = performance;
+    const { succeeded, total, playTimeAvg, playTimeMin, bestScenarioId } = performance;
 
     const computedAverage = playTimeAvg ? Number(Duration.fromISOTime(playTimeAvg).toFormat('s.SSS')).toFixed(2) : '-';
+    const computedMin = playTimeMin ? Number(Duration.fromISOTime(playTimeMin).toFormat('s.SSS')).toFixed(2) : '-';
 
     return (
         <section className="flex items-center justify-center gap-x-5">
@@ -37,7 +38,12 @@ export async function GamePerformance() {
                 stat={`${succeeded}/${total}`}
                 description="resolved scenarios"
             />
-            <GamePerformanceStat icon={Clock3} stat={`${computedAverage}`} description="seconds on average" />
+            <GamePerformanceStat icon={Clock3} stat={computedAverage} description="seconds on average" />
+            <GamePerformanceStat
+                icon={StarIcon}
+                stat={computedMin}
+                description={`best time ${bestScenarioId ? `(#${bestScenarioId})` : ''}`}
+            />
         </section>
     );
 }

--- a/components/usergame/usergames-table.tsx
+++ b/components/usergame/usergames-table.tsx
@@ -1,15 +1,15 @@
 'use client';
 
 import { ColumnDef } from '@tanstack/react-table';
-import { DataTable } from '~/components/ui/data-table';
+import { CircleCheck, CircleX } from 'lucide-react';
 import { PropsWithoutRef } from 'react';
+import { DataTable } from '~/components/ui/data-table';
 import { UserGameDeleteDialog } from '~/components/usergame/usergame-delete-dialog';
 import { usePagination } from '~/hooks/use-pagination';
-import { getCurrentUserGamesPage, getUserGamesPage } from '~/lib/actions';
 import { useTableApi } from '~/hooks/use-table-api';
 import { TableContext } from '~/hooks/use-table-context';
-import { CircleCheck, CircleX } from 'lucide-react';
-import { Duration } from 'luxon';
+import { getCurrentUserGamesPage, getUserGamesPage } from '~/lib/actions';
+import { formatDuration } from '~/lib/utils';
 
 type UserGameRow = {
     id: number;
@@ -31,11 +31,9 @@ export const userColumns: ColumnDef<UserGameRow>[] = [
     },
     {
         accessorKey: 'playTime',
-        header: () => <div className="text-center">Play Time</div>,
+        header: () => <div className="text-center">Time (seconds)</div>,
         cell: ({ row }) => (
-            <div className="text-center">
-                {row.original.success ? Duration.fromISOTime(row.original.playTime).toFormat("ss's'") : 'N/A'}
-            </div>
+            <div className="text-center">{row.original.success ? formatDuration(row.original.playTime) : 'N/A'}</div>
         )
     },
     {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,6 +1,17 @@
 import { clsx, type ClassValue } from 'clsx';
 import { twMerge } from 'tailwind-merge';
+import { Duration } from 'luxon';
 
 export function cn(...inputs: ClassValue[]) {
     return twMerge(clsx(inputs));
+}
+
+/**
+ * Formats a seconds duration string to a fixed 2 decimal number.
+ *
+ * @param duration the seconds string to format (e.g. '00:00:02.382')
+ * @returns formatted duration string, e.g. '2.38'
+ */
+export function formatDuration(duration: string) {
+    return Number(Duration.fromISOTime(duration).toFormat('s.SSS')).toFixed(2);
 }


### PR DESCRIPTION
# PR Description

<!-- Explain the goal of the PR -->

Add a new stat to game performance stats.

## How to try it

<!-- Instructions so that how a reviewer can try this locally
     Example:

     1. Navigate to the changed page
     1. Perform whatever action is required
     1. Validate that the output/user experience is as expected
-->

1. Play a few scenarios.
1. Check the new stat in `/games` page.

Checklist:

- [x] 🧐 it **works on my machine** (c)
- [x] 📋 added clear **instructions** to try it by a reviewer

## 📕 Changes made

<!-- Reviewing a PR without context is frustrating and
     (a pointless) time consuming...

     Be a nice contributor and take time to explain
     what files changed, what were you trying to achieve, why?
     explain yourself. The more you write here, the better. -->

- Get the minimum `playTime` from the `usergames` table.
- Process the value and show it (along with its associated scenario ID) in the game performance stats.

## Checklist

- [ ] 📚 kept the **docs** updated
- [x] 📕 described the **changes** in this PR description

## Related issues

<!-- List of issues resolved/canceled as a result of this PR
resolves #
fixes #
closes #
-->
