### PR TITLE
Remove best time from game stats

### DIFF
--- a/components/game/game-performance.tsx
+++ b/components/game/game-performance.tsx
@@ -1,4 +1,4 @@
-import { CircleCheck, Clock3, LucideProps, StarIcon, XCircle } from 'lucide-react';
+import { CircleCheck, Clock3, LucideProps, XCircle } from 'lucide-react';
 import { ComponentType, PropsWithoutRef } from 'react';
 import { getCurrentUserGamesPerformance } from '~/lib/actions';
 import { formatDuration } from '~/lib/utils';
@@ -26,10 +26,9 @@ export async function GamePerformance() {
         return null;
     }
 
-    const { succeeded, total, playTimeAvg, playTimeMin, bestScenarioId } = performance;
+    const { succeeded, total, playTimeAvg } = performance;
 
     const computedAverage = playTimeAvg ? formatDuration(playTimeAvg) : '-';
-    const computedMin = playTimeMin ? formatDuration(playTimeMin) : '-';
 
     return (
         <section className="flex items-center justify-center gap-x-5">
@@ -39,11 +38,6 @@ export async function GamePerformance() {
                 description="resolved scenarios"
             />
             <GamePerformanceStat icon={Clock3} stat={computedAverage} description="seconds on average" />
-            <GamePerformanceStat
-                icon={StarIcon}
-                stat={computedMin}
-                description={`best time ${bestScenarioId ? `(#${bestScenarioId})` : ''}`}
-            />
         </section>
     );
 }

--- a/lib/db/queries/usergames.ts
+++ b/lib/db/queries/usergames.ts
@@ -1,5 +1,5 @@
 import { currentUser } from '@clerk/nextjs/server';
-import { and, avg, count, eq, min } from 'drizzle-orm';
+import { and, avg, count, eq } from 'drizzle-orm';
 import { db } from '~/lib/db';
 import { UserGamesTable } from '~/lib/db/schema';
 import { UserGameInsert, UserGameSelect } from '~/lib/types';
@@ -86,33 +86,16 @@ export const getCurrentUserGamesPerformance = async () => {
     const [succeeded] = await db
         .select({
             value: count(),
-            playTimeAvg: avg(UserGamesTable.playTime),
-            playTimeMin: min(UserGamesTable.playTime)
+            playTimeAvg: avg(UserGamesTable.playTime)
         })
         .from(UserGamesTable)
         .where(and(eq(UserGamesTable.userId, user.id), eq(UserGamesTable.success, true)));
 
     const [total] = await db.select({ value: count() }).from(UserGamesTable).where(eq(UserGamesTable.userId, user.id));
 
-    let bestGame;
-    if (succeeded?.playTimeMin) {
-        [bestGame] = await db
-            .select({ id: UserGamesTable.id })
-            .from(UserGamesTable)
-            .where(
-                and(
-                    eq(UserGamesTable.userId, user.id),
-                    eq(UserGamesTable.success, true),
-                    eq(UserGamesTable.playTime, succeeded.playTimeMin)
-                )
-            );
-    }
-
     return {
         succeeded: succeeded?.value,
         total: total?.value,
-        playTimeAvg: succeeded?.playTimeAvg,
-        playTimeMin: succeeded?.playTimeMin,
-        bestScenarioId: bestGame?.id
+        playTimeAvg: succeeded?.playTimeAvg
     };
 };


### PR DESCRIPTION
<!-- List of issues resolved/canceled as a result of this PR
resolves #
fixes #
closes #
-->

resolves #240 

How to try:

<!-- Instructions so that how a reviewer can try this locally
     Example:

     1. Navigate to the changed page
     1. Perform whatever action is required
     1. Validate that the output/user experience is as expected
-->

1. In the `/games` route (or `/scores` or `/home` or whatever 😆), the best time stat should no longer appear.





