### PR TITLE
Add timestamp fields to DB tables

### DIFF
--- a/drizzle/0005_wild_quasimodo.sql
+++ b/drizzle/0005_wild_quasimodo.sql
@@ -1,0 +1,6 @@
+ALTER TABLE "scenarios" ADD COLUMN "created_at" timestamp with time zone DEFAULT now() NOT NULL;--> statement-breakpoint
+ALTER TABLE "scenarios" ADD COLUMN "updated_at" timestamp with time zone DEFAULT now() NOT NULL;--> statement-breakpoint
+ALTER TABLE "usergames" ADD COLUMN "created_at" timestamp with time zone DEFAULT now() NOT NULL;--> statement-breakpoint
+ALTER TABLE "usergames" ADD COLUMN "updated_at" timestamp with time zone DEFAULT now() NOT NULL;--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "created_at" timestamp with time zone DEFAULT now() NOT NULL;--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "updated_at" timestamp with time zone DEFAULT now() NOT NULL;

--- a/drizzle/meta/0005_snapshot.json
+++ b/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,187 @@
+{
+    "id": "2636feb7-157b-407b-842b-c1d9bdffe60c",
+    "prevId": "356051ae-4048-4165-bcb6-3633aef7e059",
+    "version": "7",
+    "dialect": "postgresql",
+    "tables": {
+        "public.scenarios": {
+            "name": "scenarios",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "serial",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "data": {
+                    "name": "data",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "active": {
+                    "name": "active",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": false
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.usergames": {
+            "name": "usergames",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "serial",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "user_id": {
+                    "name": "user_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "scenario_id": {
+                    "name": "scenario_id",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "play_time": {
+                    "name": "play_time",
+                    "type": "interval",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "success": {
+                    "name": "success",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {
+                "usergames_user_id_users_id_fk": {
+                    "name": "usergames_user_id_users_id_fk",
+                    "tableFrom": "usergames",
+                    "tableTo": "users",
+                    "columnsFrom": ["user_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                },
+                "usergames_scenario_id_scenarios_id_fk": {
+                    "name": "usergames_scenario_id_scenarios_id_fk",
+                    "tableFrom": "usergames",
+                    "tableTo": "scenarios",
+                    "columnsFrom": ["scenario_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {
+                "unique_id": {
+                    "name": "unique_id",
+                    "nullsNotDistinct": false,
+                    "columns": ["user_id", "scenario_id"]
+                }
+            },
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.users": {
+            "name": "users",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "consent": {
+                    "name": "consent",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": false
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        }
+    },
+    "enums": {},
+    "schemas": {},
+    "sequences": {},
+    "roles": {},
+    "policies": {},
+    "views": {},
+    "_meta": {
+        "columns": {},
+        "schemas": {},
+        "tables": {}
+    }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
             "when": 1738661775738,
             "tag": "0004_unusual_argent",
             "breakpoints": true
+        },
+        {
+            "idx": 5,
+            "version": "7",
+            "when": 1739264646295,
+            "tag": "0005_wild_quasimodo",
+            "breakpoints": true
         }
     ]
 }

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -1,13 +1,18 @@
 import { boolean, integer, interval, pgTable, serial, text, unique } from 'drizzle-orm/pg-core';
+import { createdAt, updatedAt } from './schemaHelpers';
 
 export const ScenariosTable = pgTable('scenarios', {
     id: serial('id').primaryKey(),
     data: text('data').notNull(),
-    active: boolean('active').default(false).notNull()
+    active: boolean('active').default(false).notNull(),
+    createdAt,
+    updatedAt
 });
 export const UsersTable = pgTable('users', {
     id: text('id').primaryKey(),
-    consent: boolean('consent').default(false).notNull()
+    consent: boolean('consent').default(false).notNull(),
+    createdAt,
+    updatedAt
 });
 
 export const UserGamesTable = pgTable(
@@ -21,7 +26,9 @@ export const UserGamesTable = pgTable(
             .references(() => ScenariosTable.id, { onDelete: 'cascade' })
             .notNull(),
         playTime: interval('play_time').notNull(),
-        success: boolean('success').notNull()
+        success: boolean('success').notNull(),
+        createdAt,
+        updatedAt
     },
     (t) => [unique('unique_id').on(t.userId, t.scenarioId)]
 );

--- a/lib/db/schemaHelpers.ts
+++ b/lib/db/schemaHelpers.ts
@@ -1,0 +1,7 @@
+import { timestamp } from 'drizzle-orm/pg-core';
+
+export const createdAt = timestamp('created_at', { withTimezone: true }).notNull().defaultNow();
+export const updatedAt = timestamp('updated_at', { withTimezone: true })
+    .notNull()
+    .defaultNow()
+    .$onUpdate(() => new Date());


### PR DESCRIPTION
<!-- List of issues resolved/canceled as a result of this PR
resolves #
fixes #
closes #
-->

resolves #280

How to try:

<!-- Instructions so that how a reviewer can try this locally
     Example:

     1. Navigate to the changed page
     1. Perform whatever action is required
     1. Validate that the output/user experience is as expected
-->

1. Test that everything is working fine.
2. Check the forked database in Neon and see the new fields.
3. Enable/disable a scenario and check that the `updated_at` field gets updated.





