### PR TITLE
Store null playTime on not resolved scenarios

### DIFF
--- a/components/game/game.tsx
+++ b/components/game/game.tsx
@@ -76,7 +76,7 @@ const Game = (props: PropsWithoutRef<GameProps>) => {
         startTransition(async () => {
             completeGameAction({
                 scenarioId: scenario.id,
-                playTime: Duration.fromMillis(elapsed).toString(),
+                playTime: gameSuccess ? Duration.fromMillis(elapsed).toString() : null,
                 success: gameSuccess
             });
         });

--- a/components/usergame/usergames-table.tsx
+++ b/components/usergame/usergames-table.tsx
@@ -26,7 +26,9 @@ const userColumns: ColumnDef<UserGameSelect>[] = [
         accessorKey: 'playTime',
         header: () => <div className="text-center">Seconds</div>,
         cell: ({ row }) => (
-            <div className="text-center">{row.original.success ? formatDuration(row.original.playTime) : 'N/A'}</div>
+            <div className="text-center">
+                {row.original.success && row.original.playTime ? formatDuration(row.original.playTime) : 'N/A'}
+            </div>
         )
     },
     {

--- a/drizzle/0006_simple_patch.sql
+++ b/drizzle/0006_simple_patch.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "usergames" ALTER COLUMN "play_time" DROP NOT NULL;
+UPDATE "usergames" SET "play_time"=NULL where "success"='f';

--- a/drizzle/meta/0006_snapshot.json
+++ b/drizzle/meta/0006_snapshot.json
@@ -1,0 +1,187 @@
+{
+    "id": "f7d5bb66-ce35-4cc6-8f6d-e909b8905af2",
+    "prevId": "2636feb7-157b-407b-842b-c1d9bdffe60c",
+    "version": "7",
+    "dialect": "postgresql",
+    "tables": {
+        "public.scenarios": {
+            "name": "scenarios",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "serial",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "data": {
+                    "name": "data",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "active": {
+                    "name": "active",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": false
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.usergames": {
+            "name": "usergames",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "serial",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "user_id": {
+                    "name": "user_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "scenario_id": {
+                    "name": "scenario_id",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "play_time": {
+                    "name": "play_time",
+                    "type": "interval",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "success": {
+                    "name": "success",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {
+                "usergames_user_id_users_id_fk": {
+                    "name": "usergames_user_id_users_id_fk",
+                    "tableFrom": "usergames",
+                    "tableTo": "users",
+                    "columnsFrom": ["user_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                },
+                "usergames_scenario_id_scenarios_id_fk": {
+                    "name": "usergames_scenario_id_scenarios_id_fk",
+                    "tableFrom": "usergames",
+                    "tableTo": "scenarios",
+                    "columnsFrom": ["scenario_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {
+                "unique_id": {
+                    "name": "unique_id",
+                    "nullsNotDistinct": false,
+                    "columns": ["user_id", "scenario_id"]
+                }
+            },
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.users": {
+            "name": "users",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "consent": {
+                    "name": "consent",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": false
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        }
+    },
+    "enums": {},
+    "schemas": {},
+    "sequences": {},
+    "roles": {},
+    "policies": {},
+    "views": {},
+    "_meta": {
+        "columns": {},
+        "schemas": {},
+        "tables": {}
+    }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
             "when": 1739264646295,
             "tag": "0005_wild_quasimodo",
             "breakpoints": true
+        },
+        {
+            "idx": 6,
+            "version": "7",
+            "when": 1739435700890,
+            "tag": "0006_simple_patch",
+            "breakpoints": true
         }
     ]
 }

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -25,7 +25,7 @@ export const UserGamesTable = pgTable(
         scenarioId: integer('scenario_id')
             .references(() => ScenariosTable.id, { onDelete: 'cascade' })
             .notNull(),
-        playTime: interval('play_time').notNull(),
+        playTime: interval('play_time'),
         success: boolean('success').notNull(),
         createdAt,
         updatedAt


### PR DESCRIPTION
<!-- List of issues resolved/canceled as a result of this PR
resolves #
fixes #
closes #
-->

resolves #248 

How to try:

<!-- Instructions so that how a reviewer can try this locally
     Example:

     1. Navigate to the changed page
     1. Perform whatever action is required
     1. Validate that the output/user experience is as expected
-->

1. When playing a scenario and not resolving it, the `play_time` column in `usergames` table should now be set to `NULL`.
2. You can test this situation and check the result on Neon.
3. Besides this, the DB migration should clear that column in the existing records (for not succeeded games).





